### PR TITLE
Use new format for batchnames

### DIFF
--- a/@RatCatcher/batchify.m
+++ b/@RatCatcher/batchify.m
@@ -24,7 +24,7 @@ function self = batchify(self)
 
   % copy over the new batch function
   copyfile(self.batchfuncpath, self.localpath);
-  corelib.verb('INFO', ['batch function copied to: ' self.localpath])
+  corelib.verb(self.verbose, 'INFO', ['batch function copied to: ' self.localpath])
 
   % save file names and cell numbers in a text file to be read out by the script
   % this format is a standard -- it will be referenced in the batch function as well
@@ -34,7 +34,7 @@ function self = batchify(self)
   % write filecodes.csv
   csvwrite(fullfile(self.localpath, ['filecodes-' self.batchname, '.csv']), self.filecodes);
 
-  corelib.verb('INFO', 'filenames and filecodes parsed')
+  corelib.verb(self.verbose, 'INFO', 'filenames and filecodes parsed')
 
 
   %% Copy over the generic script and rename
@@ -47,7 +47,7 @@ function self = batchify(self)
     % name the batch script using the same format as the filenames and filecodes
     finalScriptPath = fullfile(self.localpath, ['batchscript-', self.batchname{ii}, '.sh']);
     copyfile(dummyScriptPath, finalScriptPath);
-    corelib.verb('INFO', ['batch script copied to: ' finalScriptPath])
+    corelib.verb(self.verbose, 'INFO', ['batch script copied to: ' finalScriptPath])
 
     %% Edit the copied batch file
 
@@ -77,7 +77,7 @@ function self = batchify(self)
     filelib.write(finalScriptPath, script);
   end
 
-  corelib.verb('INFO', 'batch script edited')
-  corelib.verb('INFO', ['run this: $ qsub ' self.remotepath filesep 'batchscript-', self.batchname, '.sh'])
+  corelib.verb(self.verbose, 'INFO', 'batch script edited')
+  corelib.verb(self.verbose, 'INFO', ['run this: $ qsub ' self.remotepath filesep 'batchscript-', self.batchname, '.sh'])
 
 end % function

--- a/@RatCatcher/batchify.m
+++ b/@RatCatcher/batchify.m
@@ -20,64 +20,73 @@ function self = batchify(self)
   % erase old files
   self.clean(lamplit_filepaths);
 
-  %% Add to the directory
+  % find the dummy script by using a lazy hack
+  dummyScriptPath = which(self.batchscriptpath);
 
   % copy over the new batch function
   copyfile(self.batchfuncpath, self.localpath);
   corelib.verb(self.verbose, 'INFO', ['batch function copied to: ' self.localpath])
 
+  %% Set up scripts
+
+  % if self.batchname is a cell array, make a script for each contained character vector
+  if iscell(self.batchname)
+    for ii = 1:length(self.batchname)
+      batchify_core(self, self.batchname{ii}, dummyScriptPath);
+      corelib.verb(self.verbose, 'INFO', 'batch script edited')
+      corelib.verb(self.verbose, 'INFO', ['run this: $ qsub ' self.remotepath filesep 'batchscript-', self.batchname{ii}, '.sh'])
+    end
+  else
+    batchify_core(self, self.batchname, dummyScriptPath);
+    corelib.verb(self.verbose, 'INFO', 'batch script edited')
+    corelib.verb(self.verbose, 'INFO', ['run this: $ qsub ' self.remotepath filesep 'batchscript-', self.batchname, '.sh'])
+  end
+
+
+end % function
+
+function batchify_core(self, this_batchname, dummyScriptPath)
+  tt = '''';
+
   % save file names and cell numbers in a text file to be read out by the script
   % this format is a standard -- it will be referenced in the batch function as well
 
   % write filenames.txt
-  filelib.write(fullfile(self.localpath, ['filenames-' self.batchname '.txt']), self.filenames);
-  % write filecodes.csv
-  csvwrite(fullfile(self.localpath, ['filecodes-' self.batchname, '.csv']), self.filecodes);
+  filelib.write(fullfile(self.localpath, ['filenames-' this_batchname '.txt']), self.filenames);
 
+  % write filecodes.csv
+  csvwrite(fullfile(self.localpath, ['filecodes-' this_batchname, '.csv']), self.filecodes);
   corelib.verb(self.verbose, 'INFO', 'filenames and filecodes parsed')
 
+  % name the batch script using the same format as the filenames and filecodes
+  finalScriptPath = fullfile(self.localpath, ['batchscript-', this_batchname, '.sh']);
+  copyfile(dummyScriptPath, finalScriptPath);
+  corelib.verb(self.verbose, 'INFO', ['batch script copied to: ' finalScriptPath])
 
-  %% Copy over the generic script and rename
+  %% Edit the copied batch file
 
-  % find the dummy script by using a lazy hack
-  dummyScriptPath = which(self.batchscriptpath);
+  % useful variables
+  script    = filelib.read(finalScriptPath);
+  outfile   = fullfile(self.remotepath, ['output-', this_batchname, '-', 'SGE_TASK_ID', '.csv']);
 
-  for ii = 1:size(self.batchname, 1)
+  % TODO: make outfile more robust (accept more output types)
 
-    % name the batch script using the same format as the filenames and filecodes
-    finalScriptPath = fullfile(self.localpath, ['batchscript-', self.batchname{ii}, '.sh']);
-    copyfile(dummyScriptPath, finalScriptPath);
-    corelib.verb(self.verbose, 'INFO', ['batch script copied to: ' finalScriptPath])
+  % determine the name of the job array
+  script    = strrep(script, 'BATCH_NAME', this_batchname);
 
-    %% Edit the copied batch file
+  % determine the project name on the cluster
+  script    = strrep(script, 'PROJECT_NAME', self.project);
 
-    % useful variables
-    script    = filelib.read(finalScriptPath);
-    outfile   = fullfile(self.remotepath, ['output-', self.batchname{ii}, '-', 'SGE_TASK_ID', '.csv']);
+  % determine the number of jobs
+  script    = strrep(script, 'NUM_FILES', num2str(length(self.filenames)));
 
-    % TODO: make outfile more robust (accept more output types)
+  % determine the argument to MATLAB
+  script    = strrep(script, 'ARGUMENT', ['$SGE_TASK_ID' ', ' ...
+                    tt self.remotepath tt ', ' ...
+                    tt this_batchname tt ', ' ...
+                    tt outfile tt ', ' ...
+                    'false']);
 
-    % determine the name of the job array
-    script    = strrep(script, 'BATCH_NAME', self.batchname{ii});
-
-    % determine the project name on the cluster
-    script    = strrep(script, 'PROJECT_NAME', project);
-
-    % determine the number of jobs
-    script    = strrep(script, 'NUM_FILES', num2str(length(self.filenames)));
-
-    % determine the argument to MATLAB
-    script    = strrep(script, 'ARGUMENT', ['$SGE_TASK_ID' ', ' ...
-                      tt self.remotepath tt ', ' ...
-                      tt self.batchname{ii} tt ', ' ...
-                      tt outfile tt ', ' ...
-                      'false']);
-
-    % write to file
-    filelib.write(finalScriptPath, script);
-  end
-
-  corelib.verb(self.verbose, 'INFO', 'batch script edited')
-  corelib.verb(self.verbose, 'INFO', ['run this: $ qsub ' self.remotepath filesep 'batchscript-', self.batchname, '.sh'])
-
+  % write to file
+  filelib.write(finalScriptPath, script);
 end % function

--- a/@RatCatcher/batchify.m
+++ b/@RatCatcher/batchify.m
@@ -30,16 +30,12 @@ function self = batchify(self)
   % write filecodes.csv
   csvwrite(fullfile(self.localpath, ['filecodes-' self.batchname, '.csv']), self.filecodes);
 
-  if verbose == true
-    disp('[INFO] filenames and filecodes parsed')
-  end
+  corelib.verb('INFO', 'filenames and filecodes parsed')
 
   % copy over the new batch function
   copyfile(self.batchfuncpath, self.localpath);
 
-  if verbose == true
-    disp(['[INFO] batch function copied to: ' self.localpath])
-  end
+  corelib.verb('INFO', ['batch function copied to: ' self.localpath])
 
   %% Copy over the generic script and rename
 
@@ -49,9 +45,7 @@ function self = batchify(self)
   finalScriptPath = fullfile(self.localpath, ['batchscript-', self.batchname, '.sh']);
   copyfile(dummyScriptPath, finalScriptPath);
 
-  if verbose == true
-    disp(['[INFO] batch script copied to: ' finalScriptPath])
-  end
+  corelib.verb('INFO', ['batch script copied to: ' finalScriptPath])
 
   %% Edit the copied batch file
 
@@ -80,15 +74,7 @@ function self = batchify(self)
   % write to file
   filelib.write(finalScriptPath, script);
 
-  if verbose == true
-    disp('[INFO] batch script edited')
-  end
-
-  if verbose == true
-    disp('[INFO] DONE!')
-  end
-
-  disp(['[INFO] pass this script to qsub as an argument: ' finalScriptPath])
-
+  corelib.verb('INFO', 'batch script edited')
+  corelib.verb('INFO', ['run this: $ qsub ' self.remotepath filesep 'batchscript-', self.batchname, '.sh'])
 
 end % function

--- a/@RatCatcher/batchify.m
+++ b/@RatCatcher/batchify.m
@@ -12,20 +12,6 @@ function self = batchify(self)
 
   self        = self.validate();
 
-  % define shorthand variables
-  expID       = self.expID;
-  remotepath  = self.remotepath;
-  localpath   = self.localpath;
-  protocol    = self.protocol;
-  project     = self.project;
-  tt          = '''';
-  batchname   = self.batchname;
-  filenames   = self.filenames;
-  filecodes   = self.filecodes;
-  batchfuncpath  = self.batchfuncpath;
-  batchscriptpath  = self.batchscriptpath;
-  verbose     = self.verbose;
-
   %% Cleanup and lamplighting
 
   % perform lamplighting
@@ -40,27 +26,27 @@ function self = batchify(self)
   % this format is a standard -- it will be referenced in the batch function as well
 
   % write filenames.txt
-  filelib.write(fullfile(localpath, ['filenames-' batchname '.txt']), filenames);
+  filelib.write(fullfile(self.localpath, ['filenames-' self.batchname '.txt']), self.filenames);
   % write filecodes.csv
-  csvwrite(fullfile(localpath, ['filecodes-' batchname, '.csv']), filecodes);
+  csvwrite(fullfile(self.localpath, ['filecodes-' self.batchname, '.csv']), self.filecodes);
 
   if verbose == true
     disp('[INFO] filenames and filecodes parsed')
   end
 
   % copy over the new batch function
-  copyfile(batchfuncpath, localpath);
+  copyfile(self.batchfuncpath, self.localpath);
 
   if verbose == true
-    disp(['[INFO] batch function copied to: ' localpath])
+    disp(['[INFO] batch function copied to: ' self.localpath])
   end
 
   %% Copy over the generic script and rename
 
   % find the dummy script by using a lazy hack
-  dummyScriptPath = which(batchscriptpath);
+  dummyScriptPath = which(self.batchscriptpath);
   % name the batch script using the same format as the filenames and filecodes
-  finalScriptPath = fullfile(localpath, [batchname, '.sh']);
+  finalScriptPath = fullfile(self.localpath, [self.batchname, '.sh']);
   copyfile(dummyScriptPath, finalScriptPath);
 
   if verbose == true
@@ -71,23 +57,23 @@ function self = batchify(self)
 
   % useful variables
   script    = filelib.read(finalScriptPath);
-  outfile   = fullfile(remotepath, [batchname, '-', 'SGE_TASK_ID', '.csv']);
+  outfile   = fullfile(self.remotepath, [self.batchname, '-', 'SGE_TASK_ID', '.csv']);
 
   % TODO: make outfile more robust (accept more output types)
 
   % determine the name of the job array
-  script    = strrep(script, 'BATCH_NAME', batchname);
+  script    = strrep(script, 'BATCH_NAME', self.batchname);
 
   % determine the project name on the cluster
   script    = strrep(script, 'PROJECT_NAME', project);
 
   % determine the number of jobs
-  script    = strrep(script, 'NUM_FILES', num2str(length(filenames)));
+  script    = strrep(script, 'NUM_FILES', num2str(length(self.filenames)));
 
   % determine the argument to MATLAB
   script    = strrep(script, 'ARGUMENT', ['$SGE_TASK_ID' ', ' ...
-                    tt remotepath tt ', ' ...
-                    tt batchname tt ', ' ...
+                    tt self.remotepath tt ', ' ...
+                    tt self.batchname tt ', ' ...
                     tt outfile tt ', ' ...
                     'false']);
 

--- a/@RatCatcher/batchify.m
+++ b/@RatCatcher/batchify.m
@@ -46,7 +46,7 @@ function self = batchify(self)
   % find the dummy script by using a lazy hack
   dummyScriptPath = which(self.batchscriptpath);
   % name the batch script using the same format as the filenames and filecodes
-  finalScriptPath = fullfile(self.localpath, [self.batchname, '.sh']);
+  finalScriptPath = fullfile(self.localpath, ['batchscript-', self.batchname, '.sh']);
   copyfile(dummyScriptPath, finalScriptPath);
 
   if verbose == true
@@ -57,7 +57,7 @@ function self = batchify(self)
 
   % useful variables
   script    = filelib.read(finalScriptPath);
-  outfile   = fullfile(self.remotepath, [self.batchname, '-', 'SGE_TASK_ID', '.csv']);
+  outfile   = fullfile(self.remotepath, ['output-', self.batchname, '-', 'SGE_TASK_ID', '.csv']);
 
   % TODO: make outfile more robust (accept more output types)
 

--- a/@RatCatcher/batchify.m
+++ b/@RatCatcher/batchify.m
@@ -22,6 +22,10 @@ function self = batchify(self)
 
   %% Add to the directory
 
+  % copy over the new batch function
+  copyfile(self.batchfuncpath, self.localpath);
+  corelib.verb('INFO', ['batch function copied to: ' self.localpath])
+
   % save file names and cell numbers in a text file to be read out by the script
   % this format is a standard -- it will be referenced in the batch function as well
 
@@ -32,47 +36,46 @@ function self = batchify(self)
 
   corelib.verb('INFO', 'filenames and filecodes parsed')
 
-  % copy over the new batch function
-  copyfile(self.batchfuncpath, self.localpath);
-
-  corelib.verb('INFO', ['batch function copied to: ' self.localpath])
 
   %% Copy over the generic script and rename
 
   % find the dummy script by using a lazy hack
   dummyScriptPath = which(self.batchscriptpath);
-  % name the batch script using the same format as the filenames and filecodes
-  finalScriptPath = fullfile(self.localpath, ['batchscript-', self.batchname, '.sh']);
-  copyfile(dummyScriptPath, finalScriptPath);
 
-  corelib.verb('INFO', ['batch script copied to: ' finalScriptPath])
+  for ii = 1:size(self.batchname, 1)
 
-  %% Edit the copied batch file
+    % name the batch script using the same format as the filenames and filecodes
+    finalScriptPath = fullfile(self.localpath, ['batchscript-', self.batchname{ii}, '.sh']);
+    copyfile(dummyScriptPath, finalScriptPath);
+    corelib.verb('INFO', ['batch script copied to: ' finalScriptPath])
 
-  % useful variables
-  script    = filelib.read(finalScriptPath);
-  outfile   = fullfile(self.remotepath, ['output-', self.batchname, '-', 'SGE_TASK_ID', '.csv']);
+    %% Edit the copied batch file
 
-  % TODO: make outfile more robust (accept more output types)
+    % useful variables
+    script    = filelib.read(finalScriptPath);
+    outfile   = fullfile(self.remotepath, ['output-', self.batchname{ii}, '-', 'SGE_TASK_ID', '.csv']);
 
-  % determine the name of the job array
-  script    = strrep(script, 'BATCH_NAME', self.batchname);
+    % TODO: make outfile more robust (accept more output types)
 
-  % determine the project name on the cluster
-  script    = strrep(script, 'PROJECT_NAME', project);
+    % determine the name of the job array
+    script    = strrep(script, 'BATCH_NAME', self.batchname{ii});
 
-  % determine the number of jobs
-  script    = strrep(script, 'NUM_FILES', num2str(length(self.filenames)));
+    % determine the project name on the cluster
+    script    = strrep(script, 'PROJECT_NAME', project);
 
-  % determine the argument to MATLAB
-  script    = strrep(script, 'ARGUMENT', ['$SGE_TASK_ID' ', ' ...
-                    tt self.remotepath tt ', ' ...
-                    tt self.batchname tt ', ' ...
-                    tt outfile tt ', ' ...
-                    'false']);
+    % determine the number of jobs
+    script    = strrep(script, 'NUM_FILES', num2str(length(self.filenames)));
 
-  % write to file
-  filelib.write(finalScriptPath, script);
+    % determine the argument to MATLAB
+    script    = strrep(script, 'ARGUMENT', ['$SGE_TASK_ID' ', ' ...
+                      tt self.remotepath tt ', ' ...
+                      tt self.batchname{ii} tt ', ' ...
+                      tt outfile tt ', ' ...
+                      'false']);
+
+    % write to file
+    filelib.write(finalScriptPath, script);
+  end
 
   corelib.verb('INFO', 'batch script edited')
   corelib.verb('INFO', ['run this: $ qsub ' self.remotepath filesep 'batchscript-', self.batchname, '.sh'])

--- a/@RatCatcher/clean.m
+++ b/@RatCatcher/clean.m
@@ -9,8 +9,25 @@ function clean(self, keepthis)
 
   warning off all
 
+  % if self.batchname is a cell array, run recursively for each contained character vector
+  count = 0;
+  if iscell(self.batchname)
+    for ii = 1:length(self.batchname)
+      count = count + clean_core(self, self.batchname{ii}, keepthis);
+    end
+  else
+    count = clean_core(self, self.batchname, keepthis);
+  end
+
+  corelib.verb(self.verbose, 'INFO', ['all old files removed (', num2str(count), ' files)'])
+
+  warning on all
+
+end % function
+
+function count = clean_core(self, this_batchname, keepthis)
   % make a list of all files in the localpath directory containing the batchname in the filename
-  dd = dir(fullfile(self.localpath, ['*', self.batchname, '*']));
+  dd = dir(fullfile(self.localpath, ['*', this_batchname, '*']));
   files2delete = {dd.name};
 
   % remove the files not flagged for keeping
@@ -21,9 +38,4 @@ function clean(self, keepthis)
       count = count + 1;
     end
   end
-
-  if self.verbose == true
-    disp(['[INFO] all old files removed (', num2str(count), ' files)'])
-  end
-
-  warning on all
+end % function

--- a/@RatCatcher/getBatchScriptName.m
+++ b/@RatCatcher/getBatchScriptName.m
@@ -19,7 +19,6 @@ function batchname = getBatchScriptName(self)
       end
       batchname{ii} = [batchname{ii} '-' self.protocol];
     end
-    batchname = [batchname '-' self.protocol];
 
   else
     batchname = [self.expID '-' self.protocol];

--- a/@RatCatcher/getBatchScriptName.m
+++ b/@RatCatcher/getBatchScriptName.m
@@ -3,6 +3,25 @@ function batchname = getBatchScriptName(self)
   % the basic form is self.expID + self.protocol
   % where batchname is a cell array of size n x 1
   % where n is the number of rows in self.
+  %
+  % batchname = r.getBatchScriptName()
+  %
+  % Example:
+  %
+  %   >> r.getBatchScriptName
+  %
+  % ans =
+  %
+  %   5×1 cell array
+  %
+  %     {'Caitlin-A-BandwidthEstimator'}
+  %     {'Caitlin-B-BandwidthEstimator'}
+  %     {'Caitlin-C-BandwidthEstimator'}
+  %     {'Caitlin-D-BandwidthEstimator'}
+  %     {'Caitlin-E-BandwidthEstimator'}
+  %
+  %
+  % See also RatCatcher, RatCatcher.getBatchScriptPath
 
   if isempty(self.expID)
     batchname = ['test' '-' self.protocol];

--- a/@RatCatcher/getBatchScriptName.m
+++ b/@RatCatcher/getBatchScriptName.m
@@ -1,25 +1,28 @@
 function batchname = getBatchScriptName(self)
   % comes up with a verbose name that unambiguously identifies any batchname file
+  % the basic form is self.expID + self.protocol
+  % where batchname is a cell array of size n x 1
+  % where n is the number of rows in self.
 
-  expID     = self.expID;
-  protocol  = self.protocol;
-
-  if isempty(expID)
-    batchname = ['test' '-' protocol];
+  if isempty(self.expID)
+    batchname = ['test' '-' self.protocol];
     return
   end
 
-  if iscell(expID)
-    expID  = expID';
-    batchname = expID{1};
+  if iscell(self.expID)
+    batchname = cell(size(self.expID, 1), 1);
 
-    for ii = 2:numel(expID)
-      batchname = [batchname '-' expID{ii}];
+    for ii = 1:size(self.expID, 1)
+      batchname{ii} = self.expID{ii, 1};
+      for qq = 1:size(self.expID, 2)
+        batchname{ii} = [batchname{ii} '-' self.expID{ii, qq}];
+      end
+      batchname{ii} = [batchname{ii} '-' self.protocol];
     end
+    batchname = [batchname '-' self.protocol];
 
-    batchname = [batchname '-' protocol];
   else
-    batchname = [expID '-' protocol];
+    batchname = [self.expID '-' self.protocol];
   end
 
 end % function

--- a/@RatCatcher/getBatchScriptName.m
+++ b/@RatCatcher/getBatchScriptName.m
@@ -14,7 +14,7 @@ function batchname = getBatchScriptName(self)
 
     for ii = 1:size(self.expID, 1)
       batchname{ii} = self.expID{ii, 1};
-      for qq = 1:size(self.expID, 2)
+      for qq = 2:size(self.expID, 2)
         batchname{ii} = [batchname{ii} '-' self.expID{ii, qq}];
       end
       batchname{ii} = [batchname{ii} '-' self.protocol];


### PR DESCRIPTION
`r.batchname` can now be a cell array and every function that needs to iterates over the character vectors contained within.