### PR TITLE
Exp id parallel batchify

### DIFF
--- a/@RatCatcher/RatCatcher.m
+++ b/@RatCatcher/RatCatcher.m
@@ -61,7 +61,7 @@ properties
   % can be 'single' or 'multi'
 
   nbins
-  % positive integer
+  % positive integer or vector of positive integers
   % only matters when mode = 'parallel'
   % used to determine the number of batches run on the cluster
 

--- a/@RatCatcher/batchify.m
+++ b/@RatCatcher/batchify.m
@@ -35,12 +35,12 @@ function self = batchify(self)
   % if self.batchname is a cell array, make a script for each contained character vector
   if iscell(self.batchname)
     for ii = 1:length(self.batchname)
-      batchify_core(self, self.batchname{ii}, self.filenames{ii}, self.filecodes{ii}, dummyScriptPath);
+      batchify_core(self, self.batchname{ii}, self.filenames{ii}, self.filecodes{ii}, self.nbins(ii), dummyScriptPath);
       corelib.verb(self.verbose, 'RatCatcher::batchify', 'batch script edited')
       corelib.verb(self.verbose, 'RatCatcher::batchify', ['run this: $ qsub ' self.remotepath filesep 'batchscript-', self.batchname{ii}, '.sh'])
     end
   else
-    batchify_core(self, self.batchname, self.filenames, self.filecodes, dummyScriptPath);
+    batchify_core(self, self.batchname, self.filenames, self.filecodes, self.nbins, dummyScriptPath);
     corelib.verb(self.verbose, 'RatCatcher::batchify', 'batch script edited')
     corelib.verb(self.verbose, 'RatCatcher::batchify', ['run this: $ cd ' self.remotepath '; qsub ' 'batchscript-', self.batchname, '.sh'])
   end
@@ -48,7 +48,7 @@ function self = batchify(self)
 
 end % function
 
-function batchify_core(self, batchname, filenames, filecodes, dummyScriptPath)
+function batchify_core(self, batchname, filenames, filecodes, nbins, dummyScriptPath)
   tt = '''';
 
   % save file names and cell numbers in a text file to be read out by the script
@@ -86,7 +86,7 @@ function batchify_core(self, batchname, filenames, filecodes, dummyScriptPath)
   % set the number of files (occurs for parallel and array jobs)
   script    = strrep(script, 'NUM_FILES', num2str(length(filenames)));
   % set the number of bins (occurs for only parallel jobs)
-  script    = strrep(script, 'NUM_BINS', num2str(self.nbins));
+  script    = strrep(script, 'NUM_BINS', num2str(nbins));
 
   %% Add flags if necessary
 

--- a/@RatCatcher/gather.m
+++ b/@RatCatcher/gather.m
@@ -119,7 +119,7 @@ function dataTable = gather(self, filekey, dataTable0)
     % get the dimensions of the data
     dim1      = length(outfiles);
     % read through the files and write the data to a matrix
-    data      = NaN([dim1 size(csvread(outfiles{1}))]);
+    data      = NaN([dim1 size(readmatrix(outfiles{1}))]);
     corelib.verb(self.verbose, 'RatCatcher::gather', 'reading outfiles to build data matrix')
 
     %% Collect the data from the csv files

--- a/@RatCatcher/gather.m
+++ b/@RatCatcher/gather.m
@@ -186,7 +186,7 @@ function dataTable = gather(self, filekey, dataTable0)
       l2d_df     = data(:, 7);
       d2l_df     = data(:, 8);
       % concatenate into a table
-      dataTable(l2d_h, l2d_p, l2d_tstat, l2d_df, d2l_h, d2l_p, d2l_tstat, d2l_df);
+      dataTable = table(l2d_h, l2d_p, l2d_tstat, l2d_df, d2l_h, d2l_p, d2l_tstat, d2l_df);
     otherwise
       corelib.verb(true, 'RatCatcher::gather', 'I don''t know which protocol you mean.')
     end

--- a/@RatCatcher/gather.m
+++ b/@RatCatcher/gather.m
@@ -127,11 +127,11 @@ function dataTable = gather(self, filekey, dataTable0)
     if self.verbose
       for ii = 1:dim1
         corelib.textbar(ii, dim1)
-        data(ii, :) = corelib.vectorise(csvread(outfiles{ii}));
+        data(ii, :) = corelib.vectorise(readmatrix(outfiles{ii}));
       end
     else
       for ii = 1:dim1
-        data(ii, :) = corelib.vectorise(csvread(outfiles{ii}));
+        data(ii, :) = corelib.vectorise(readmatrix(outfiles{ii}));
       end
     end
 

--- a/@RatCatcher/getNBins.m
+++ b/@RatCatcher/getNBins.m
@@ -1,0 +1,39 @@
+function nbins = getNBins(self)
+
+    % determines the number of bins used for parallelized array jobs
+    % assumes that the number of cores is 16
+    %
+    %% Arguments:
+    % self: a RatCatcher object
+    %
+    %% Outputs:
+    % nbins: a scalar if self.expID is a character vector or cell array row vector
+    %   a vector if self.expID is a cell array column vector or matrix
+    %   is empty is self.mode is not 'parallel'
+    
+    if strcmp(self.mode, 'parallel')
+        if iscell(self.expID)
+            % expID is a cell array
+            if size(self.expID, 1) > 1
+                % expID is a cell array with multiple rows
+                % nbins is a vector
+                nbins = NaN(size(self.expID, 1), 1);
+                % iterate through expID row-wise to generate the number of bins
+                for ii = 1:size(self.expID, 1)
+                    nbins(ii) = ceil(length(self.filenames{ii}) / 16);
+                end
+            else
+                % expID is a single row cell array
+                % nbins is a scalar
+                nbins = ceil(length(self.filenames) / 16);
+            end
+        else
+            % expID is a character vector
+            % nbins is a scalar
+            nbins = ceil(length(self.filenames) / 16);
+        end
+    else
+        nbins = [];
+    end
+
+end % function

--- a/@RatCatcher/getNBins.m
+++ b/@RatCatcher/getNBins.m
@@ -9,7 +9,7 @@ function nbins = getNBins(self)
     %% Outputs:
     % nbins: a scalar if self.expID is a character vector or cell array row vector
     %   a vector if self.expID is a cell array column vector or matrix
-    %   is empty is self.mode is not 'parallel'
+    %   is empty if self.mode is not 'parallel'
     %
     %% Example:
     %

--- a/@RatCatcher/getNBins.m
+++ b/@RatCatcher/getNBins.m
@@ -10,7 +10,14 @@ function nbins = getNBins(self)
     % nbins: a scalar if self.expID is a character vector or cell array row vector
     %   a vector if self.expID is a cell array column vector or matrix
     %   is empty is self.mode is not 'parallel'
-    
+    %
+    %% Example:
+    %
+    %   nbins = self.getNBins();
+    %
+
+    nThreads = 16;
+
     if strcmp(self.mode, 'parallel')
         if iscell(self.expID)
             % expID is a cell array
@@ -20,17 +27,17 @@ function nbins = getNBins(self)
                 nbins = NaN(size(self.expID, 1), 1);
                 % iterate through expID row-wise to generate the number of bins
                 for ii = 1:size(self.expID, 1)
-                    nbins(ii) = ceil(length(self.filenames{ii}) / 16);
+                    nbins(ii) = ceil(length(self.filenames{ii}) / nThreads);
                 end
             else
                 % expID is a single row cell array
                 % nbins is a scalar
-                nbins = ceil(length(self.filenames) / 16);
+                nbins = ceil(length(self.filenames) / nThreads);
             end
         else
             % expID is a character vector
             % nbins is a scalar
-            nbins = ceil(length(self.filenames) / 16);
+            nbins = ceil(length(self.filenames) / nThreads);
         end
     else
         nbins = [];

--- a/@RatCatcher/validate.m
+++ b/@RatCatcher/validate.m
@@ -94,7 +94,7 @@ function self = validate(self)
   switch self.mode
   case 'parallel'
     if isempty(self.nbins)
-      self.nbins = ceil(length(self.filenames) / 16);
+      self.nbins = self.getNBins();
       corelib.verb(self.verbose, 'RatCatcher::validate', 'nbins determined automatically')
     else
       corelib.verb(self.verbose, 'RatCatcher::validate', 'nbins determined by user')


### PR DESCRIPTION
Allow `r.mode='parallel'` to work with cell arrays of `r.expID`. Other minor quality-of-life improvements and bugfixes.